### PR TITLE
Allowed for versions of nokogiri >= 1.5.0.beta.4

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
   specs:
     jruby-lint (0.3.0)
       jruby-openssl
-      nokogiri (= 1.5.0.beta.4)
+      nokogiri (>= 1.5.0.beta.4)
       term-ansicolor
 
 GEM
@@ -40,7 +40,7 @@ GEM
     jruby-openssl (0.7.4)
       bouncy-castle-java
     json (1.5.1-java)
-    nokogiri (1.5.0.beta.4-java)
+    nokogiri (1.5.0-java)
     rake (0.8.7)
     rb-fsevent (0.4.0)
     rspec (2.5.0)

--- a/jruby-lint.gemspec
+++ b/jruby-lint.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "term-ansicolor"
   s.add_dependency "jruby-openssl"
-  s.add_dependency "nokogiri", "= 1.5.0.beta.4"
+  s.add_dependency "nokogiri", ">= 1.5.0.beta.4"
   s.add_development_dependency "rake"
   s.add_development_dependency "rspec", ">= 2.5"
   s.add_development_dependency "rspec-given"


### PR DESCRIPTION
I did some basic tests, ran the specs, etc. 4 specs failed, but they seem to fail regardless of nokogiri version.  Otherwise, nokogiri 1.5.0 seems to work fine.  Thanks.
